### PR TITLE
chore(3.12): replace pkg_resources with importlib

### DIFF
--- a/kineticsTools/ipdModel.py
+++ b/kineticsTools/ipdModel.py
@@ -1,4 +1,4 @@
-from pkg_resources import Requirement, resource_filename
+from importlib import resources
 import logging
 import gzip
 import os.path as op
@@ -47,8 +47,11 @@ codeToBase = dict([(y, x) for (x, y) in baseToCode.items()])
 
 
 def _getAbsPath(fname):
-    return resource_filename(Requirement.parse(
-        'kineticsTools'), 'kineticsTools/%s' % fname)
+    try:
+        with resources.as_file(resources.files('kineticsTools') / fname) as path:
+            return str(path)
+    except:
+        return os.path.join(os.path.dirname(__file__), path)
 
 
 class GbmContextModel(object):

--- a/kineticsTools/ipdSummary.py
+++ b/kineticsTools/ipdSummary.py
@@ -20,7 +20,7 @@ import threading
 import numpy as np
 import queue
 import traceback
-from pkg_resources import Requirement, resource_filename
+from importlib import resources
 
 from pbcommand.common_options import add_debug_option
 from pbcommand.cli import get_default_argparser_with_base_opts, pacbio_args_runner
@@ -43,9 +43,11 @@ class Constants(object):
 
 
 def _getResourcePathSpec():
-    default_dir = resource_filename(Requirement.parse(
-        'kineticsTools'), 'kineticsTools/resources')
-    return loader.getResourcePathSpec(default_dir)
+    try:
+        with resources.as_file(resources.files('kineticTools') / 'resources') as path:
+            return loader.getResourcePathSpec(path)
+    except:
+        return loader.getResourcePathSpec(os.path.join(os.path.dirname(__file__), 'resources'))
 
 
 def _validateResource(func, p):


### PR DESCRIPTION
Python 3.12 removes setuptools from the default installation. Replace usage of pkg_resources with importlib.

I have added except: case to allow testing without install.